### PR TITLE
BT load on the fly fixed

### DIFF
--- a/nav2_bt_modes_navigator/src/bt_modes_navigator.cpp
+++ b/nav2_bt_modes_navigator/src/bt_modes_navigator.cpp
@@ -318,7 +318,13 @@ BtNavigator::on_parameter_event_callback(
     if (type == ParameterType::PARAMETER_STRING) {
       if (name == "bt_xml_filename") {
         new_behavior_tree_ = true;
-        bt_xml_filename_ = value.string_value;
+        
+        std::string fullpath = bt_xml_filename_;
+        int beginIdx = fullpath.rfind('/');
+        std::string filename = fullpath.substr(beginIdx + 1);
+        fullpath.erase(fullpath.begin() + beginIdx + 1, fullpath.end());
+        
+        bt_xml_filename_ = fullpath + value.string_value;
       }
     }
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation turtlebot3 |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

I have fixed the load of a new behavior_tree on the fly, before this, the new BT had to located in the same dir that you launch the navigation. Now the new BT has to locate in the same directory that the original BT.

---


Best
